### PR TITLE
berks 3/ Ridley compat fix

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,7 @@ license          "Apache 2.0"
 description      "Installs/Configures APT unattended_upgrades"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.0.2"
+name             "unattended_upgrades"
 
 %w{ ubuntu debian }.each do |os|
     supports os


### PR DESCRIPTION
While 'name' is not required Ridley, a gem used by berkshelf 3/ vagrant-berkshelf, requires it.
