### PR TITLE
make readme tool-friendly markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-= Description
+## Description
 
 Configure APT to do unattended upgrades as security fixes are released.
 
-= Requirements
+## Requirements
 
 Ubuntu or maybe Debian.
 
@@ -12,7 +12,7 @@ Tested on:
 * Ubuntu 12.04 LTS wtih chef-client 10.14.2
 * Ubuntu 14.04 LTS with chef-client 11.12.2
 
-= Attributes
+## Attributes
 
 The following node attributes are passed to the APT configuration template:
 
@@ -20,17 +20,17 @@ The following node attributes are passed to the APT configuration template:
 * unattended_upgrades[:auto_reboot] - automatically reboot without confirmation if necessary (default false)
 * unattended_upgrades[:enable_upgrades] - enable or disable unattended upgrades (default true)
 
-= Usage
+## Usage
 
-  include_recipe "unattended_upgrades"
+    include_recipe "unattended_upgrades"
 
-= Contributing
+## Contributing
 
 https://github.com/mcary/unattended_upgrades
 
-== Testing
+### Testing
 
-  $ vagrant up $ver
-  $ vagrant ssh $ver -- sudo sh /vagrant/test.sh
+    $ vagrant up $ver
+    $ vagrant ssh $ver -- sudo sh /vagrant/test.sh
 
 Where $ver is 10.04, 12.04, or 14.04.

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ maintainer       "Marcel M. Cary"
 maintainer_email "marcel@oak.homeunix.org"
 license          "Apache 2.0"
 description      "Installs/Configures APT unattended_upgrades"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.0"
 name             "unattended_upgrades"
 


### PR DESCRIPTION
This is most prominent in the Supermarket, which only parses Markdown: https://supermarket.chef.io/cookbooks/unattended_upgrades