### PR TITLE
Allow running upgrades immediately after installation.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,3 +3,5 @@ default[:unattended_upgrades][:auto_reboot] = false
 default[:unattended_upgrades][:enable_upgrades] = true
 
 default[:unattended_upgrades][:blacklist] = %w() # %w(vim libc6 libc6-dev libc6-i686)
+
+default[:unattended_upgrades][:run_immediately] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,7 +5,9 @@
 # Required for problem notification
 package "mailutils"
 
-package "unattended-upgrades"
+package "unattended-upgrades" do
+  notifies :run, 'execute[unattended-upgrades]', :delayed if node[:unattended_upgrades][:run_immediately]
+end
 
 template "/etc/apt/apt.conf.d/50unattended-upgrades" do
   mode "444"
@@ -14,4 +16,8 @@ template "/etc/apt/apt.conf.d/50unattended-upgrades" do
     :auto_reboot => node[:unattended_upgrades][:auto_reboot],
     :enable_upgrades => node[:unattended_upgrades][:enable_upgrades]
   )
+end
+
+execute 'unattended-upgrades' do
+  action :nothing
 end


### PR DESCRIPTION
This change will force an unattended-upgrades run after it is installed the first time.

This is useful for dynamically provisioned nodes, where the longevity of a particular node may be too short to ensure upgrades are ever run.